### PR TITLE
feat(ui): redesign client layout with dark mode

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -95,58 +95,25 @@ test(playlist): add validation test cases
 
 ## Prototype Architecture
 
-### Client-Server Setup
+See `prototype/client/AGENTS.md` for Next.js client instructions.
+
+### Server Setup
 **Server**: Cloudflare Worker (TypeScript) - API backend deployed to Workers
-**Client**: Next.js (TypeScript) - UI frontend deployed to Cloudflare Pages
-
-### Two-Panel UI Layout (Next.js Client)
-**Left Panel**: DP-1 playlist player with artwork rendering and controls
-**Right Panel**: Chat interface for natural language commands
-
-### Communication Flow
-```
-Next.js Client → Cloudflare Worker API → Response
-Chat Panel → PUT /api/playlist → Player Panel Update
-```
 
 ### Configuration
 **Worker**: TypeScript with ES modules, `compatibility_date = "2025-03-07"`
-**Next.js**: Static export for Cloudflare Pages deployment
 
 ## Dev Environment Tips
 
-### Workspace Management
-- Use `pnpm dlx turbo run dev --filter <project_name>` to jump to a specific package
-- Run `pnpm install --filter <project_name>` to add packages to workspace
-- Use `pnpm create next-app@latest <project_name> --typescript --tailwind --eslint --app` for Next.js client
-- Check the `name` field in each package's `package.json` for correct package names
-
 ### Quick Commands
 ```bash
-# Development (run both simultaneously)
+# Development
 npx wrangler dev --port 8787 --live-reload  # Worker server
-pnpm dev --filter prototype-ui               # Next.js client
 
 # Testing
 npx vitest run                               # Worker tests
-pnpm test --filter prototype-ui              # Next.js tests
 
 # Deployment
-wrangler deploy --env staging                # Deploy Worker
-pnpm build && pnpm pages:deploy              # Deploy Next.js to Pages
-```
-
-### Next.js + Cloudflare Pages Setup
-```bash
-# Configure Next.js for static export (required for Pages)
-# Add to next.config.js:
-# output: 'export'
-# trailingSlash: true
-# images: { unoptimized: true }
-
-# Deploy to Cloudflare Pages
-pnpm add @cloudflare/next-on-pages
-pnpm build
-npx @cloudflare/next-on-pages
+wrangler deploy --env staging
 ```
 

--- a/README.md
+++ b/README.md
@@ -33,8 +33,11 @@ prototype/  - Cloudflare Workers reference implementation
    ```
    Deploy the client to Pages and the API worker separately.
    See the [Cloudflare Pages documentation](https://developers.cloudflare.com/pages/llms-full.txt) for details.
-   The client features a two-panel UI where the right panel accepts curl-style commands and displays the API response.
+ The client features a responsive three-panel UI (player, chat, and document). The chat panel shows a message-style log with the command box at the bottom.
 3. **Build Hardware**: Use the spec to implement DP-1 on your preferred platform
+
+### Headless Testing
+Run `npm run headless` to build the client and verify the UI with Puppeteer. This test should pass before submitting client changes.
 
 ## AI-First Philosophy
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,9 +9,11 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
+        "marked": "^15.0.12",
         "next": "^15.3.3",
         "react": "^19.1.0",
-        "react-dom": "^19.1.0"
+        "react-dom": "^19.1.0",
+        "react-resizable-panels": "^3.0.3"
       },
       "devDependencies": {
         "@cloudflare/workers-types": "^4.20250614.0",
@@ -3480,6 +3482,18 @@
         "@jridgewell/sourcemap-codec": "^1.5.0"
       }
     },
+    "node_modules/marked": {
+      "version": "15.0.12",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-15.0.12.tgz",
+      "integrity": "sha512-8dD6FusOQSrpv9Z1rdNMdlSgQOIP880DHqnohobOmYLElGEqAL/JvxvuxZO16r4HtjTlfPRDC1hbvxC9dPN2nA==",
+      "license": "MIT",
+      "bin": {
+        "marked": "bin/marked.js"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
     "node_modules/mime": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/mime/-/mime-3.0.0.tgz",
@@ -4410,6 +4424,16 @@
       },
       "peerDependencies": {
         "react": "^19.1.0"
+      }
+    },
+    "node_modules/react-resizable-panels": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/react-resizable-panels/-/react-resizable-panels-3.0.3.tgz",
+      "integrity": "sha512-7HA8THVBHTzhDK4ON0tvlGXyMAJN1zBeRpuyyremSikgYh2ku6ltD7tsGQOcXx4NKPrZtYCm/5CBr+dkruTGQw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.14.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc",
+        "react-dom": "^16.14.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc"
       }
     },
     "node_modules/require-directory": {

--- a/package.json
+++ b/package.json
@@ -18,9 +18,11 @@
   "license": "ISC",
   "type": "module",
   "dependencies": {
+    "marked": "^15.0.12",
     "next": "^15.3.3",
     "react": "^19.1.0",
-    "react-dom": "^19.1.0"
+    "react-dom": "^19.1.0",
+    "react-resizable-panels": "^3.0.3"
   },
   "devDependencies": {
     "@cloudflare/workers-types": "^4.20250614.0",
@@ -30,10 +32,10 @@
     "@types/react-dom": "^19.1.6",
     "autoprefixer": "^10.4.21",
     "postcss": "^8.5.5",
+    "puppeteer": "^22.8.0",
     "tailwindcss": "^4.1.10",
     "typescript": "^5.8.3",
     "vitest": "^3.2.3",
-    "wrangler": "^4.20.0",
-    "puppeteer": "^22.8.0"
+    "wrangler": "^4.20.0"
   }
 }

--- a/prototype/client/AGENTS.md
+++ b/prototype/client/AGENTS.md
@@ -1,0 +1,49 @@
+# DP-1 Client Guidelines
+
+This file contains guidance specific to the Next.js client located in this directory.
+
+## Prototype Architecture
+
+### Client-Server Setup
+**Server**: Cloudflare Worker (TypeScript) - API backend deployed to Workers
+**Client**: Next.js (TypeScript) - UI frontend deployed to Cloudflare Pages
+
+### Three-Panel UI Layout
+**Player Panel**: Artwork player on the left
+**Chat Panel**: Command interface in the center
+**Document Panel**: DP-1 specification on the right
+
+### Communication Flow
+```
+Next.js Client → Cloudflare Worker API → Response
+Chat Panel → PUT /api/playlist → Player Panel Update
+```
+
+### Configuration
+**Next.js**: Static export for Cloudflare Pages deployment
+
+## Dev Environment Tips
+
+### Workspace Management
+- Use `pnpm dlx turbo run dev --filter <project_name>` to jump to a specific package
+- Run `pnpm install --filter <project_name>` to add packages to workspace
+- Use `pnpm create next-app@latest <project_name> --typescript --tailwind --eslint --app` for Next.js client
+- Check the `name` field in each package's `package.json` for correct package names
+
+### Quick Commands
+```bash
+# Development
+pnpm dev                                     # Next.js client
+# Testing
+npm run headless                             # Headless UI test
+pnpm test --filter prototype-ui              # Next.js tests
+# Deployment
+pnpm build && pnpm pages:deploy              # Deploy to Cloudflare Pages
+```
+
+### Headless Testing
+Any modification to the client code must run the headless test:
+```bash
+npm run headless
+```
+The script builds the client and verifies the UI with Puppeteer. Ensure Node.js v18+ is installed.

--- a/prototype/client/pages/_app.tsx
+++ b/prototype/client/pages/_app.tsx
@@ -2,5 +2,9 @@ import type { AppProps } from 'next/app';
 import '../styles/globals.css';
 
 export default function App({ Component, pageProps }: AppProps) {
-  return <Component {...pageProps} />;
+  return (
+    <div className="dark min-h-screen font-roboto">
+      <Component {...pageProps} />
+    </div>
+  );
 }

--- a/prototype/client/styles/globals.css
+++ b/prototype/client/styles/globals.css
@@ -1,3 +1,8 @@
+@import url('https://fonts.googleapis.com/css2?family=Roboto:wght@400;700&display=swap');
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
+
+body {
+  font-family: 'Roboto', sans-serif;
+}

--- a/prototype/client/tailwind.config.js
+++ b/prototype/client/tailwind.config.js
@@ -4,8 +4,13 @@ module.exports = {
     './pages/**/*.{ts,tsx}',
     './components/**/*.{ts,tsx}'
   ],
+  darkMode: 'class',
   theme: {
-    extend: {},
+    extend: {
+      fontFamily: {
+        roboto: ['Roboto', 'sans-serif'],
+      },
+    },
   },
   plugins: [],
 };

--- a/tests/headless.js
+++ b/tests/headless.js
@@ -45,12 +45,12 @@ async function main() {
   });
 
   await page.waitForFunction(() => {
-    const logs = document.querySelectorAll('pre');
+    const logs = document.querySelectorAll('.chat-log pre');
     return logs.length && logs[logs.length - 1].textContent.includes('result');
   });
 
   const state = await page.evaluate(() => localStorage.getItem('dp1_state'));
-  const chat = await page.evaluate(() => document.querySelectorAll('pre')[0].textContent);
+  const chat = await page.evaluate(() => document.querySelector('.chat-log pre')?.textContent);
 
   const firstSrc = await page.$eval('iframe', el => el.getAttribute('src'));
   await new Promise(r => setTimeout(r, 1500));


### PR DESCRIPTION
## Summary
- introduce dedicated `prototype/client/AGENTS.md`
- document headless test workflow in README
- enable Roboto font and Tailwind dark mode
- redesign index page with resizable panels and iOS-style chat bubbles
- update headless test to target chat log

## Testing
- `npm test`
- `npm run headless`


------
https://chatgpt.com/codex/tasks/task_e_684ff05f12e0832293b93f0c54a37124