### PR TITLE
feat(ui): modular client with signed playlists

### DIFF
--- a/docs/api/README.md
+++ b/docs/api/README.md
@@ -49,6 +49,15 @@ Example response snippet:
 }
 ```
 
+### POST `/api/v1/playlists`
+
+Submit a playlist for validation. The body must include `items[]`, `signature`, and the Ed25519 `pubkey` used to sign the SHA-256 hash of the JSON.
+
+```bash
+curl -X POST /api/v1/playlists \
+  -d '{"items":[{"id":"a","source":"https://example.com/a","duration":5}],"signature":"ed25519:<hex>","pubkey":"<hex>"}'
+```
+
 ## Deployment
 
 The API worker runs on Cloudflare Workers. The accompanying Next.js client is hosted on Cloudflare Pages. See the [Cloudflare Pages documentation](https://developers.cloudflare.com/pages/llms-full.txt) for deployment steps.

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
+        "@noble/ed25519": "^1.7.5",
         "marked": "^15.0.12",
         "next": "^15.3.3",
         "react": "^19.1.0",
@@ -1285,6 +1286,18 @@
       "engines": {
         "node": ">= 10"
       }
+    },
+    "node_modules/@noble/ed25519": {
+      "version": "1.7.5",
+      "resolved": "https://registry.npmjs.org/@noble/ed25519/-/ed25519-1.7.5.tgz",
+      "integrity": "sha512-xuS0nwRMQBvSxDa7UxMb61xTiH3MxTgUfhyPUALVIe0FlOAz4sjELwyDRyUvqeEYfRSG9qNjFIycqLZppg4RSA==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://paulmillr.com/funding/"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/@puppeteer/browsers": {
       "version": "2.3.0",

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
   "license": "ISC",
   "type": "module",
   "dependencies": {
+    "@noble/ed25519": "^1.7.5",
     "marked": "^15.0.12",
     "next": "^15.3.3",
     "react": "^19.1.0",

--- a/prototype/client/components/Chat.tsx
+++ b/prototype/client/components/Chat.tsx
@@ -1,0 +1,50 @@
+import { useState } from 'react';
+
+export type LogEntry = { command: string; response: string };
+
+interface ChatProps {
+  log: LogEntry[];
+  setLog: (l: LogEntry[]) => void;
+  onSend: (command: string) => Promise<string>;
+}
+
+export default function Chat({ log, setLog, onSend }: ChatProps) {
+  const [curl, setCurl] = useState('');
+
+  const example = () => {
+    setCurl('curl -X GET /api/v1/playlists');
+  };
+
+  const send = async () => {
+    const resp = await onSend(curl);
+    const text = JSON.stringify(JSON.parse(resp), null, 2);
+    setLog([...log, { command: curl, response: text }]);
+    setCurl('');
+  };
+
+  return (
+    <div className="flex flex-col h-full">
+      <h1 className="text-xl font-bold mb-2">Chat Panel</h1>
+      <div className="chat-log flex-1 overflow-y-auto space-y-2 pr-1">
+        {log.map((l, i) => (
+          <div key={i}>
+            <div className="flex justify-end">
+              <div className="bg-blue-600 text-white px-3 py-1 rounded-lg font-mono whitespace-pre-wrap max-w-xs">
+                {l.command}
+              </div>
+            </div>
+            <div className="flex justify-start mt-1">
+              <pre className="bg-gray-700 px-3 py-1 rounded-lg whitespace-pre-wrap max-w-xs">{l.response}</pre>
+            </div>
+          </div>
+        ))}
+      </div>
+      <div className="mt-2">
+        <button className="bg-gray-700 px-2 py-1 mr-2" onClick={example}>Example</button>
+        <textarea className="border w-full p-2 mt-2 text-black" rows={4} value={curl} onChange={e => setCurl(e.target.value)} placeholder="curl command" />
+        <button className="mt-2 bg-blue-600 text-white px-2 py-1" onClick={send}>Send</button>
+      </div>
+    </div>
+  );
+}
+

--- a/prototype/client/components/Document.tsx
+++ b/prototype/client/components/Document.tsx
@@ -1,0 +1,9 @@
+interface DocProps {
+  html: string;
+}
+
+export default function DocumentPanel({ html }: DocProps) {
+  return (
+    <div className="prose dark:prose-invert max-w-none" dangerouslySetInnerHTML={{ __html: html }} />
+  );
+}

--- a/prototype/client/components/Player.tsx
+++ b/prototype/client/components/Player.tsx
@@ -1,0 +1,35 @@
+import { useEffect, useRef, useState } from 'react';
+
+interface PlayerProps {
+  playlist: any[];
+}
+
+export default function Player({ playlist }: PlayerProps) {
+  const [index, setIndex] = useState(0);
+  const itemStartRef = useRef(Date.now());
+
+  useEffect(() => {
+    if (!playlist[index]) return;
+    const item = playlist[index];
+    const now = Date.now();
+    const elapsed = now - itemStartRef.current;
+    const duration = Number(item.duration) > 0 ? Number(item.duration) * 1000 : 5000;
+    const remaining = duration - elapsed;
+    const timer = setTimeout(() => {
+      itemStartRef.current = Date.now();
+      setIndex(i => (i + 1) % playlist.length);
+    }, remaining > 0 ? remaining : 0);
+    return () => clearTimeout(timer);
+  }, [playlist, index]);
+
+  if (!playlist.length) return <div className="flex-1" />;
+
+  return (
+    <iframe
+      key={playlist[index].id}
+      src={playlist[index].source}
+      allow="*"
+      className="flex-1 w-full border"
+    />
+  );
+}

--- a/prototype/client/pages/_app.tsx
+++ b/prototype/client/pages/_app.tsx
@@ -2,9 +2,5 @@ import type { AppProps } from 'next/app';
 import '../styles/globals.css';
 
 export default function App({ Component, pageProps }: AppProps) {
-  return (
-    <div className="dark min-h-screen font-roboto">
-      <Component {...pageProps} />
-    </div>
-  );
+  return <Component {...pageProps} />;
 }

--- a/prototype/client/pages/_document.tsx
+++ b/prototype/client/pages/_document.tsx
@@ -1,0 +1,13 @@
+import { Html, Head, Main, NextScript } from 'next/document';
+
+export default function Document() {
+  return (
+    <Html className="dark">
+      <Head />
+      <body className="min-h-screen font-roboto bg-gray-900 text-gray-100">
+        <Main />
+        <NextScript />
+      </body>
+    </Html>
+  );
+}

--- a/prototype/client/pages/index.tsx
+++ b/prototype/client/pages/index.tsx
@@ -1,19 +1,15 @@
-import { useEffect, useRef, useState } from 'react';
+import { useEffect, useState } from 'react';
 import { PanelGroup, Panel, PanelResizeHandle } from 'react-resizable-panels';
 import type { GetStaticProps } from 'next';
 import fs from 'fs/promises';
 import path from 'path';
 import { marked } from 'marked';
+import Player from '../components/Player';
+import Chat, { LogEntry } from '../components/Chat';
+import DocumentPanel from '../components/Document';
 import playlistsData from '../../src/data/playlists.json';
 import playlistGroupsData from '../../src/data/playlist-groups.json';
-
-type LogEntry = { command: string; response: string };
-
-interface PlayerState {
-  playlist: any[];
-  index: number;
-  itemStartedAt: number;
-}
+import { verify } from '@noble/ed25519';
 
 const STATE_KEY = 'dp1_state';
 const CHAT_KEY = 'dp1_chat';
@@ -28,20 +24,15 @@ function validateItems(items: any[]): any[] {
 }
 
 export default function Home({ docHtml }: { docHtml: string }) {
-  const [curl, setCurl] = useState('');
   const [log, setLog] = useState<LogEntry[]>([]);
   const [playlist, setPlaylist] = useState<any[]>([]);
-  const [index, setIndex] = useState(0);
-  const itemStartRef = useRef(Date.now());
 
   useEffect(() => {
     const saved = localStorage.getItem(STATE_KEY);
     if (saved) {
       try {
-        const state: PlayerState = JSON.parse(saved);
+        const state = JSON.parse(saved);
         setPlaylist(state.playlist || []);
-        setIndex(state.index || 0);
-        itemStartRef.current = state.itemStartedAt || Date.now();
       } catch {}
     }
     const savedChat = localStorage.getItem(CHAT_KEY);
@@ -51,119 +42,78 @@ export default function Home({ docHtml }: { docHtml: string }) {
   }, []);
 
   useEffect(() => {
-    if (!playlist[index]) return;
-    const item = playlist[index];
-    const now = Date.now();
-    const elapsed = now - itemStartRef.current;
-    const duration = Number(item.duration) > 0 ? Number(item.duration) * 1000 : 5000;
-    const remaining = duration - elapsed;
-    const timer = setTimeout(() => {
-      itemStartRef.current = Date.now();
-      setIndex(i => (i + 1) % playlist.length);
-    }, remaining > 0 ? remaining : 0);
-    localStorage.setItem(
-      STATE_KEY,
-      JSON.stringify({ playlist, index, itemStartedAt: itemStartRef.current })
-    );
-    return () => clearTimeout(timer);
-  }, [playlist, index]);
+    localStorage.setItem(STATE_KEY, JSON.stringify({ playlist }));
+  }, [playlist]);
 
-  const example = () => {
-    setCurl('curl -X GET /api/v1/playlists');
-  };
-
-  const send = async () => {
+  const handleCommand = async (curl: string) => {
     const methodMatch = curl.match(/-X\s+(\w+)/);
     const urlMatch = curl.match(/(\/api\S+)/);
     const bodyMatch = curl.match(/-d\s+'([^']+)'/);
-    const headerMatches = [...curl.matchAll(/-H\s+"([^:]+):\s*([^\"]+)"/g)];
     const method = methodMatch ? methodMatch[1] : 'GET';
     const url = urlMatch ? urlMatch[1] : '/';
-    const headers: Record<string, string> = {};
-    for (const m of headerMatches) headers[m[1]] = m[2];
     const body = bodyMatch ? bodyMatch[1] : undefined;
-
     const response = await handleLocalApi(method, url, body);
     let logObj: Record<string, string> = {};
     if (Array.isArray(response)) {
       const items = validateItems(response[0]?.items || []);
       if (items.length > 0) {
         setPlaylist(items);
-        setIndex(0);
-        itemStartRef.current = Date.now();
         logObj = { result: 'ok' };
       } else {
-        logObj = { error: 'invalid_playlist' };
+        logObj = { error: 'playlistInvalid' };
       }
     } else if (response.playlist) {
       const items = validateItems(response.playlist);
       if (items.length > 0) {
         setPlaylist(items);
-        setIndex(0);
-        itemStartRef.current = Date.now();
         logObj = { result: 'ok' };
       } else {
-        logObj = { error: 'invalid_playlist' };
+        logObj = { error: 'playlistInvalid' };
       }
     } else if (response.error) {
       logObj = { error: response.error };
     } else {
       logObj = { error: 'unsupported' };
     }
-
     const text = JSON.stringify(logObj, null, 2);
-    setLog(l => {
-      const updated = [...l, { command: curl, response: text }];
-      localStorage.setItem(CHAT_KEY, JSON.stringify(updated));
-      return updated;
-    });
+    const updated = [...log, { command: curl, response: text }];
+    setLog(updated);
+    localStorage.setItem(CHAT_KEY, JSON.stringify(updated));
+    return JSON.stringify(logObj);
   };
 
   return (
-    <div className="h-screen bg-gray-900 text-gray-100">
+    <div className="h-screen">
       <PanelGroup direction="horizontal" className="h-full">
         <Panel defaultSize={33} className="flex flex-col p-4 border-r border-gray-700">
           <h1 className="text-xl font-bold mb-2">Player Panel</h1>
-          {playlist.length > 0 && (
-            <iframe
-              key={playlist[index].id}
-              src={playlist[index].source}
-              allow="*"
-              className="flex-1 w-full border"
-            />
-          )}
+          <Player playlist={playlist} />
         </Panel>
         <PanelResizeHandle className="w-1 bg-gray-700 hover:bg-gray-600" />
         <Panel defaultSize={34} className="flex flex-col p-4 border-r border-gray-700">
-          <h1 className="text-xl font-bold mb-2">Chat Panel</h1>
-          <div className="chat-log flex-1 overflow-y-auto space-y-2 pr-1">
-            {log.map((l, i) => (
-              <div key={i}>
-                <div className="flex justify-end">
-                  <div className="bg-blue-600 text-white px-3 py-1 rounded-lg font-mono whitespace-pre-wrap max-w-xs">
-                    {l.command}
-                  </div>
-                </div>
-                <div className="flex justify-start mt-1">
-                  <pre className="bg-gray-700 px-3 py-1 rounded-lg whitespace-pre-wrap max-w-xs">{l.response}</pre>
-                </div>
-              </div>
-            ))}
-          </div>
-          <div className="mt-2">
-            <button className="bg-gray-700 px-2 py-1 mr-2" onClick={example}>Example</button>
-            <textarea className="border w-full p-2 mt-2 text-black" rows={4} value={curl} onChange={e => setCurl(e.target.value)} placeholder="curl command" />
-            <button className="mt-2 bg-blue-600 text-white px-2 py-1" onClick={send}>Send</button>
-          </div>
+          <Chat log={log} setLog={setLog} onSend={handleCommand} />
         </Panel>
         <PanelResizeHandle className="w-1 bg-gray-700 hover:bg-gray-600" />
         <Panel defaultSize={33} className="p-4 overflow-y-auto">
           <h1 className="text-xl font-bold mb-2">Document</h1>
-          <div className="prose dark:prose-invert max-w-none" dangerouslySetInnerHTML={{ __html: docHtml }} />
+          <DocumentPanel html={docHtml} />
         </Panel>
       </PanelGroup>
     </div>
   );
+}
+
+async function verifySignature(obj: any) {
+  if (!obj.signature || !obj.pubkey) return false;
+  const sigHex = obj.signature.split(':')[1];
+  const sig = Uint8Array.from(Buffer.from(sigHex, 'hex'));
+  const pub = Uint8Array.from(Buffer.from(obj.pubkey, 'hex'));
+  const clone = { ...obj };
+  delete clone.signature;
+  delete clone.pubkey;
+  const enc = new TextEncoder();
+  const hash = new Uint8Array(await crypto.subtle.digest('SHA-256', enc.encode(JSON.stringify(clone))));
+  return verify(sig, hash, pub);
 }
 
 async function handleLocalApi(method: string, url: string, body?: string) {
@@ -179,9 +129,12 @@ async function handleLocalApi(method: string, url: string, body?: string) {
     try {
       const data = JSON.parse(body || '{}');
       if (Array.isArray(data.items)) {
-        return { playlist: data.items };
+        if (await verifySignature(data)) {
+          return { playlist: data.items };
+        }
+        return { error: 'sigInvalid' };
       }
-      return { error: 'invalid_format' };
+      return { error: 'playlistInvalid' };
     } catch {
       return { error: 'invalid_json' };
     }

--- a/prototype/src/data/playlist-groups.json
+++ b/prototype/src/data/playlist-groups.json
@@ -6,7 +6,8 @@
     "summary": "Exploring procedural form…",
     "playlists": [
       "https://feed.ff.com/geom-p1/playlist.json",
-      "https://feed.ff.com/geom-p2/playlist.json"
+      "https://feed.ff.com/geom-p2/playlist.json",
+      "https://feed.ff.com/demo1/playlist.json"
     ],
     "created": "2025-05-20T00:00:00Z",
     "coverImage": "ipfs://bafyb.../cover.jpg"

--- a/prototype/src/data/playlists.json
+++ b/prototype/src/data/playlists.json
@@ -17,5 +17,16 @@
     "items": [
       {"id": "g2-1", "source": "https://example.com/art3.html", "duration": 12}
     ]
+  },
+  {
+    "id": "demo1",
+    "title": "Demo",
+    "chain": "tezos",
+    "type": "code",
+    "items": [
+      {"id": "a", "source": "https://example.com/a", "duration": 10}
+    ],
+    "signature": "ed25519:0a74db066ce2bc9e9390169f5eb9b7532a661a05c9924d50b64e6c7fa2d8eb12db2c6204c25725e4ea595fad0a902361446dc1747430cd2da7d5cf24a334730f",
+    "pubkey": "9414133c5617d8b67d817c895a0827c9d494ced441e400b797e2c37a6bef965f"
   }
 ]

--- a/tests/headless.js
+++ b/tests/headless.js
@@ -33,11 +33,13 @@ async function main() {
 
   const browser = await puppeteer.launch({ headless: 'new', args: ['--no-sandbox', '--disable-setuid-sandbox'] });
   const page = await browser.newPage();
+  page.on('console', msg => console.log('page-log', msg.text()));
   await page.goto('http://localhost:3000');
+  await page.waitForSelector('textarea');
 
   await page.evaluate(() => localStorage.clear());
 
-  const curl = "curl -X POST /api/v1/playlists -d '{\"items\":[{\"id\":\"a\",\"source\":\"https://example.com/a\",\"duration\":1},{\"id\":\"b\",\"source\":\"https://example.com/b\",\"duration\":1}]}'";
+  const curl = "curl -X POST /api/v1/playlists -d '{\"items\":[{\"id\":\"a\",\"source\":\"https://example.com/a\",\"duration\":1},{\"id\":\"b\",\"source\":\"https://example.com/b\",\"duration\":1}],\"signature\":\"ed25519:b85e26e24e061bcd63b83fe289cacc32140a70c49af3c177d8b33191a3687e07e2fe5b10877ffb3c40383ab8a87e8d34a1e7a0800e0b87ce3241f92b2cb33a0f\",\"pubkey\":\"dc9d83435cc336f16e1bebe812f2cc4990f8939441182443cc3916e56054290b\"}'";
   await page.type('textarea', curl);
   await page.$$eval('button', btns => {
     const b = btns.find(el => el.textContent.trim() === 'Send');


### PR DESCRIPTION
## Summary
- refactor player, chat, and document into independent components
- verify playlist Ed25519 signatures in the demo player
- document playlist submission endpoint in API docs
- add `_document.tsx` for dark mode
- extend data sets with signed playlist example
- update headless test with signed playlist

## Testing
- `npm test`
- `npm run headless`

------
https://chatgpt.com/codex/tasks/task_e_684ff8cc0f948322a29b65d8a428c690