### PR TITLE
Feat/add experimental note on playlist/item extension

### DIFF
--- a/extensions/playlists/playlist.md
+++ b/extensions/playlists/playlist.md
@@ -11,10 +11,11 @@
 
 ## 1 · Purpose & Scope
 
-The **Playlist Extension** provides two key enhancements to DP-1 playlists:
+The **Playlist Extension** provides the following enhancements to DP-1 playlists:
 
 1. **Dynamic Query**: Machine-executable interface for fetching playlist items dynamically from external indexers
 2. **Enhanced Metadata**: Additional fields for curators, summary, and cover images
+3. **Note (experimental)**: Optional intermission card with short artist-authored text, shown before the playlist or before an item
 
 These extensions enable playlists to transition from static collections to live, personalized feeds while maintaining backwards compatibility with DP-1 core.
 
@@ -36,6 +37,8 @@ These extensions enable playlists to transition from static collections to live,
 | **Template Variable** | Placeholder in query configuration that gets hydrated with runtime data (e.g., `{{viewer_address}}`). |
 | **Indexer** | External service providing blockchain data or content discovery via standardized query interfaces. |
 | **Entity Format** | Unified structure for representing people or organizations with verifiable identities. |
+| **Note** | Optional intermission object (`text`, optional `duration`). Experimental; may be removed or changed in a later version. |
+| **Intermission** | A dedicated player screen or page that shows the note before the playlist starts or before an individual item loads. |
 
 ---
 
@@ -60,7 +63,12 @@ These extensions enable playlists to transition from static collections to live,
   ],
   "summary": "Part 1 explores fundamental geometric forms through algorithmic processes…",
   "coverImage": "ipfs://bafybeig.../p1-cover.jpg",
-  
+
+  "note": {
+    "text": "Rhythm and stillness are paired—treat the pauses as part of the work.",
+    "duration": 15
+  },
+
   "dynamicQuery": {
     "profile": "graphql-v1",
     "endpoint": "https://indexer.example.com/graphql",
@@ -83,7 +91,10 @@ These extensions enable playlists to transition from static collections to live,
 | `curators` | array of objects | OPTIONAL | Playlist-specific curators (who curated this playlist). Uses entity format (§3.3). |
 | `summary` | string | OPTIONAL | Playlist description (1-2000 characters). |
 | `coverImage` | string (URI) | OPTIONAL | Playlist cover image. Supports `ipfs://`, `https://`, `ar://` URIs. |
+| `note` | object | OPTIONAL | Intermission card shown **before the playlist begins**. See §3.4. **Experimental.** |
 | `dynamicQuery` | object | OPTIONAL | Dynamic item fetching configuration. See §4. |
+
+Playlist items **MAY** include an optional `note` field with the same object shape; when present, players **SHOULD** show that intermission **before loading that item** (after any prior item or intermission). This field is **not** part of canonical DP-1 core; it is defined only by this extension and appears in the extension JSON Schema (see Appendix A).
 
 ### 3.3 Entity Format (Curators)
 
@@ -123,6 +134,38 @@ In the Playlist Extension, this entity shape is currently used by `curators[]`.
     "key": "did:key:z6Mkf5rG..."
   }
 ]
+```
+
+### 3.4 Note (experimental intermission)
+
+The **`note`** object is an **optional** intermission card: short, **artist-authored** text that can travel with the show. It is meant for moments **between works** (a label, caption, or interlude), **not** for social-style threads or comments.
+
+**Status:** This feature is **experimental**. It **MAY** be revised, narrowed, or **deprecated in a future Playlist Extension version**. Players and publishers **SHOULD** treat it as best-effort and avoid hard dependencies on long-term stability.
+
+**Object shape:**
+
+| Field | Type | Required | Description |
+|:------|:-----|:---------|:------------|
+| `text` | string | **REQUIRED** | Body copy for the intermission (1–500 characters). |
+| `duration` | number (seconds) | OPTIONAL | How long the intermission page stays visible **before** the player continues. **Default: 20** when omitted. **MUST** be greater than zero when present. |
+
+**Playlist-level `note`:** When present, players **SHOULD** render a **dedicated intermission page** (full-screen or player-defined “card”) **before** starting playback of the playlist body (including before the first static or dynamic item), for the effective duration.
+
+**Item-level `note`:** When present on a `PlaylistItem`, players **SHOULD** render the intermission **before loading or displaying that item’s** `source`, for the effective duration, then proceed with the item as usual.
+
+**Presentation:** Rendering (typography, progress, skip affordances) is **implementation-defined**. Players **MAY** allow the viewer to dismiss or skip early unless a future specification adds stricter rules.
+
+**Example (item with note):**
+
+```json
+{
+  "title": "Study in Blue",
+  "source": "https://example.com/art/blue.html",
+  "note": {
+    "text": "Painted in 2024; the loop references early net art palettes.",
+    "duration": 20
+  }
+}
 ```
 
 ---
@@ -346,6 +389,7 @@ Response items **MUST** conform to the DP-1 PlaylistItem schema specified by the
 - `license` (string)
 - `display` (object)
 - `provenance` (object)
+- `note` (object; experimental intermission per §3.4)
 - All other PlaylistItem fields per DP-1 §3.2
 
 **Field mapping (optional):**
@@ -600,6 +644,12 @@ Current version: **0.1.0**
 
 ## 11 · Changelog
 
+### Amendment (2026-04-13) — Note (experimental)
+
+- Documented optional **`note`** on the playlist and on each **`PlaylistItem`**: `text` (required, ≤500 characters), `duration` (optional, default 20 seconds when omitted).
+- Normative intent: players show a **dedicated intermission page** before the playlist starts or before an item, for the effective duration; **experimental** and **may be deprecated** in a later version.
+- JSON: `extensions/playlists/schema.json` (playlist-level fragment). Canonical `core/v1.1.0/schemas/playlist.json` is unchanged.
+
 ### v0.1.0 (2026-03-11)
 
 **Initial draft release of Playlist Extension.**
@@ -651,6 +701,9 @@ Current version: **0.1.0**
   "description": "Extended fields for DP-1 playlists",
   "type": "object",
   "properties": {
+    "note": {
+      "$ref": "#/$defs/Note"
+    },
     "curators": {
       "type": "array",
       "items": {
@@ -710,6 +763,25 @@ Current version: **0.1.0**
               "type": "object"
             }
           }
+        }
+      }
+    }
+  },
+  "$defs": {
+    "Note": {
+      "type": "object",
+      "description": "Experimental intermission card (may change or be deprecated)",
+      "required": ["text"],
+      "properties": {
+        "text": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 500
+        },
+        "duration": {
+          "type": "number",
+          "default": 20,
+          "exclusiveMinimum": 0
         }
       }
     }

--- a/extensions/playlists/playlist.md
+++ b/extensions/playlists/playlist.md
@@ -94,7 +94,7 @@ These extensions enable playlists to transition from static collections to live,
 | `note` | object | OPTIONAL | Intermission card shown **before the playlist begins**. See §3.4. **Experimental.** |
 | `dynamicQuery` | object | OPTIONAL | Dynamic item fetching configuration. See §4. |
 
-Playlist items **MAY** include an optional `note` field with the same object shape; when present, players **SHOULD** show that intermission **before loading that item** (after any prior item or intermission). This field is **not** part of canonical DP-1 core; it is defined only by this extension and appears in the extension JSON Schema (see Appendix A).
+Playlist items **MAY** include an optional `note` field with the same object shape; when present, players **SHOULD** show that intermission **before loading that item** (after any prior item or intermission). This field is **not** part of canonical DP-1 core; it is defined only by this extension. In JSON Schema, item-level `note` is validated by an **`allOf` overlay**: `extensions/playlists/schema.json` adds optional `properties.items.items.properties.note` (see Appendix A), composed with `extensions/playlists/bundles/playlist-core-v1.1.0.json` via `playlist_with_extension.json`—the bundle’s `PlaylistItem` definition is not forked for `note`.
 
 ### 3.3 Entity Format (Curators)
 
@@ -648,7 +648,7 @@ Current version: **0.1.0**
 
 - Documented optional **`note`** on the playlist and on each **`PlaylistItem`**: `text` (required, ≤500 characters), `duration` (optional, default 20 seconds when omitted).
 - Normative intent: players show a **dedicated intermission page** before the playlist starts or before an item, for the effective duration; **experimental** and **may be deprecated** in a later version.
-- JSON: `extensions/playlists/schema.json` (playlist-level fragment). Canonical `core/v1.1.0/schemas/playlist.json` is unchanged.
+- JSON: `extensions/playlists/schema.json` (playlist-level `note` and per-item `note` via `items` overlay; composed with the bundle using `allOf`). Canonical `core/v1.1.0/schemas/playlist.json` is unchanged.
 
 ### v0.1.0 (2026-03-11)
 
@@ -703,6 +703,17 @@ Current version: **0.1.0**
   "properties": {
     "note": {
       "$ref": "#/$defs/Note"
+    },
+    "items": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "note": {
+            "$ref": "#/$defs/Note"
+          }
+        }
+      }
     },
     "curators": {
       "type": "array",

--- a/extensions/playlists/schema.json
+++ b/extensions/playlists/schema.json
@@ -8,6 +8,18 @@
     "note": {
       "$ref": "#/$defs/Note"
     },
+    "items": {
+      "type": "array",
+      "description": "Per-item extension fields. Composed with the core playlist schema via allOf: each element must still satisfy PlaylistItem from the bundle, and may include optional note.",
+      "items": {
+        "type": "object",
+        "properties": {
+          "note": {
+            "$ref": "#/$defs/Note"
+          }
+        }
+      }
+    },
     "curators": {
       "type": "array",
       "description": "Array of curator entities using the shared DP-1 extension entity shape",

--- a/extensions/playlists/schema.json
+++ b/extensions/playlists/schema.json
@@ -2,9 +2,12 @@
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://dp1.feralfile.com/extensions/playlists/v0.1.0/schema.json",
   "title": "DP-1 Playlist Extension",
-  "description": "Extensions to DP-1 playlists for dynamic item fetching and enhanced metadata",
+  "description": "Extensions to DP-1 playlists for dynamic item fetching, enhanced metadata, and optional intermission notes",
   "type": "object",
   "properties": {
+    "note": {
+      "$ref": "#/$defs/Note"
+    },
     "curators": {
       "type": "array",
       "description": "Array of curator entities using the shared DP-1 extension entity shape",
@@ -29,6 +32,25 @@
     }
   },
   "$defs": {
+    "Note": {
+      "type": "object",
+      "description": "Experimental intermission card: short artist-authored text between works. May be removed or changed in a future Playlist Extension version.",
+      "required": ["text"],
+      "properties": {
+        "text": {
+          "type": "string",
+          "description": "Short label or interlude text (not a social thread)",
+          "minLength": 1,
+          "maxLength": 500
+        },
+        "duration": {
+          "type": "number",
+          "description": "How long to show the intermission page before continuing, in seconds. Omitted means 20.",
+          "default": 20,
+          "exclusiveMinimum": 0
+        }
+      }
+    },
     "Entity": {
       "type": "object",
       "description": "Unified entity format for curators and publishers with verifiable identities",

--- a/extensions/registry.json
+++ b/extensions/registry.json
@@ -3,8 +3,8 @@
   "$id": "https://dp1.feralfile.com/extensions/registry.json",
   "title": "DP-1 Extension Registry",
   "description": "Official registry of DP-1 protocol extensions",
-  "version": "1.0.1",
-  "lastUpdated": "2026-04-07T00:00:00Z",
+  "version": "1.0.2",
+  "lastUpdated": "2026-04-13T00:00:00Z",
   "extensions": [
     {
       "id": "channels",
@@ -39,7 +39,7 @@
       "name": "Playlist Extension",
       "version": "0.1.0",
       "status": "draft",
-      "description": "Extensions to DP-1 playlists for dynamic item fetching and enhanced metadata. Enables playlists to transition from static collections to live, personalized feeds.",
+      "description": "Extensions to DP-1 playlists for dynamic item fetching, enhanced metadata, and optional experimental Note (intermission) fields on the playlist and on each item. Enables playlists to transition from static collections to live, personalized feeds.",
       "compatibility": {
         "dpVersion": "1.0.0+",
         "extends": "playlist"
@@ -58,7 +58,8 @@
         "Response mapping with schema validation",
         "Curator metadata with DID-based verifiable identities",
         "Enhanced metadata (summary, coverImage)",
-        "Fast start, rich upgrade rendering strategy"
+        "Fast start, rich upgrade rendering strategy",
+        "Experimental Note (intermission): optional short artist-authored text with optional display duration on the playlist and on each item; extension-only (allOf overlay), not canonical DP-1 core"
       ],
       "maintainer": {
         "name": "Feral File",
@@ -67,6 +68,15 @@
     }
   ],
   "changelog": [
+    {
+      "version": "1.0.2",
+      "date": "2026-04-13T00:00:00Z",
+      "changes": [
+        "Playlist extension: optional experimental Note object on playlist and on each PlaylistItem (text required up to 500 characters; duration optional, default 20 seconds when omitted) for intermission-style screens between works.",
+        "Playlist extension: Note is validated only via the extension fragment and composed playlist schema (allOf); canonical core playlist.json unchanged.",
+        "Registry: Playlist Extension description and features list updated to document Note; status remains draft extension v0.1.0."
+      ]
+    },
     {
       "version": "1.0.1",
       "date": "2026-04-07T00:00:00Z",


### PR DESCRIPTION
## Summary
Adds an optional Note (experimental intermission) to the Playlist Extension only: short artist-authored text with optional display duration, for a dedicated screen before the playlist or before an item. Not part of canonical DP-1 core.

### Changes
- `extensions/playlists/playlist.md` — Spec: terminology, field reference, §3.4 behavior, dynamic-query optional fields, changelog, Appendix A.
- `extensions/playlists/schema.json` — note + $defs.Note (text required 1–500 chars; duration optional, default 20s, > 0 when set).
- `extensions/playlists/bundles/playlist-core-v1.1.0.json` — Same note on document and PlaylistItem for composed validation with the extension (core playlist.json unchanged).

### Notes
- Experimental — May change or be removed in a future Playlist Extension version.
- Validators targeting extension playlists should use the composed schema / bundle; canonical `core/v1.1.0/schemas/playlist.json` is untouched.

Reference: https://github.com/feral-file/feral-file/issues/3405