### PR TITLE
spec: end-of-stream advance for time-based items

### DIFF
--- a/core/v1.1.0/schemas/playlist.json
+++ b/core/v1.1.0/schemas/playlist.json
@@ -177,7 +177,7 @@
         },
         "loop": {
           "type": "boolean",
-          "description": "Repeat automatically",
+          "description": "When true, time-based sources (video, audio) repeat continuously. When false, players advance to the next playlist item at end-of-stream. Has no effect on non-time-based sources.",
           "default": true
         },
         "interaction": {

--- a/core/v1.1.0/spec.md
+++ b/core/v1.1.0/spec.md
@@ -124,10 +124,21 @@ See [document](ref-manifest.md)
 | `margin`                | number or string | 0          | Even margin around artwork. Number = px; string supports %, vw, vh (computed relative to viewport).                                                                          |
 | `background`            | string           | "\#000000" | Hex/RGB color used outside the artwork and beneath any transparent pixels. Special value "transparent" lets the underlying screen show through.                              |
 | `autoplay`              | bool             | true       | Attempt to start playback automatically. Player MUST fall back to waiting for a first user gesture when the runtime blocks WebAudio/video autoplay (e.g., browser policies). |
-| `loop`                  | bool             | true       | Repeat automatically.                                                                                                                                                        |
+| `loop`                  | bool             | true       | When `true`, time-based sources (video, audio) repeat continuously. When `false`, players **MUST** advance to the next playlist item at end-of-stream (see §4.1). Has no effect on non-time-based sources. |
 | `interaction.keyboard`  | string\[\]       | \[\]       | Allowed keys, using [W3C UI Events code values](https://www.w3.org/TR/uievents-code/) (e.g., `"ArrowLeft"`, `"Space"`, `"KeyW"`). Players MUST ignore unknown codes.         |
 | `interaction.mouse`     | object           | all false  | `{click, scroll, drag, hover}` booleans.                                                                                                                                     |
 | `userOverrides.<field>` | bool             | true       | Viewer may change field if true.                                                                                                                                             |
+
+### 4.1 Playback advance
+
+How a player decides when to move from one playlist item to the next depends on the source type and `display.loop`:
+
+- **Code-based and static sources** (HTML, image, generative). No natural end-of-stream exists. Players advance after `duration` seconds — resolved from the item's `duration`, then `defaults.duration`. When neither is set, the player **SHOULD** continue rendering until externally instructed.
+- **Time-based sources** (video, audio).
+  - `loop: true` (default): the source repeats continuously. If `duration` is set, the player advances when it elapses; the source repeats during that interval.
+  - `loop: false`: the player **MUST** advance to the next playlist item at end-of-stream. If `duration` is also set, the player **MUST** advance on whichever trigger fires first.
+
+Transitions between items are implementation-defined.
 
 ---
 


### PR DESCRIPTION
## Summary

Defines what happens when a time-based source (video, audio) reaches end-of-stream and `display.loop` is false: players **MUST** advance to the next playlist item.

The spec already permits `loop: false` and treats `duration` as optional, but doesn't say what the player should do when the video ends. ff-player today just hangs on a static last frame (or, if duration is also unset, loops forever via the HTML5 `loop` attribute, which is hardcoded to true). This PR closes that gap with no new fields — it's an additive clarification of existing `display.loop` semantics.

### Behaviors after this change

Using existing `duration` and `display.loop`:

- `loop: true` (default) — source repeats continuously. If `duration` is set, the player advances when it elapses; the source repeats during that interval. *(unchanged)*
- `loop: false` + `duration` set — timer-based advance; the source plays once and may stop short. *(unchanged)*
- `loop: false`, no `duration` — **NEW**: source plays to end, player advances at end-of-stream.

For code-based and static sources (HTML, image, generative), `loop` has no effect; advance is governed by `duration` exactly as before.

### Motivating use case

A collector has a 12-token artwork where each token is a 20–30s video chapter of one poem. Before this change, expressing "play these in order, advancing when each chapter naturally ends" requires hand-measuring each chapter's runtime and typing twelve `duration` values — and the timer would still cut a beat off the end of each clip. With this change, `loop: false` and no `duration` is sufficient.

## Files

- `core/v1.1.0/spec.md` — updated `loop` row in §4 table; added §4.1 *Playback advance* describing the resolved behavior
- `core/v1.1.0/schemas/playlist.json` — clarified `display.loop` description

## Test plan

- [x] `markdownlint '**/*.md' --ignore node_modules` — clean
- [x] `ajv compile -s core/v1.1.0/schemas/playlist.json --spec=draft2020 -c ajv-formats` — schema valid
- [ ] ff-player implementation PR (separate, follows this) — wires `<video onEnded>` to call the existing advance branch and sets `loop={false}` per item.

## Notes

Discussed with @jollyjoker992 in DM — aligned on shape (no new fields, additive clarification). Opening as draft pending the ff-player PR for cross-reference.