### PR TITLE
Rename: FF1 → Art Computer in reference hardware paragraph

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ If signatures are present, add `--pubkey` as required by your validation flow.
 
 ## Reference hardware path
 
-FF1 is a reference hardware/player path for DP-1, not the definition of DP-1 itself.
+The Art Computer (model FF1) is a reference hardware/player path for DP-1, not the definition of DP-1 itself.
 
 ## Guided integration flow
 


### PR DESCRIPTION
## Summary

One-line update in `README.md` § Reference hardware path. The DP-1 spec README mentions the reference hardware for DP-1 playback; rename to the new product name with the model designation in parens so DP-1 integrators can still tie the hardware to FF1 when they need to.

**Before:** `FF1 is a reference hardware/player path for DP-1, not the definition of DP-1 itself.`

**After:** `The Art Computer (model FF1) is a reference hardware/player path for DP-1, not the definition of DP-1 itself.`

## Context

Part of the FF1/FFP → Art Computer/Art Panel naming rollout. Earlier work updated docs.feralfile.com (`feral-file/docs#163`) and the Canon docs to use the new name; this is the last bit in the protocol README to match.