### PR TITLE
ci(lint): resolve cross-schema $refs when compiling schemas

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -46,10 +46,25 @@ jobs:
         run: |
           echo "Validating JSON Schema files structure..."
           # Find all JSON files in any 'schemas' folder and any files ending with 'schema.json'
-          find . -type f \( -path "*/schemas/*.json" -o -name "*schema.json" \) -not -path "./node_modules/*" | while read schema; do
+          mapfile -t schemas < <(
+            find . -type f \( -path "*/schemas/*.json" -o -name "*schema.json" \) \
+              -not -path "./node_modules/*" | sort
+          )
+          # Every other schema is registered with -r so that a cross-schema
+          # "$ref" by $id resolves (e.g. the playlists extension referencing
+          # core ref-manifest.json). The schema under compile is excluded from
+          # its own -r set, since re-adding it would be a duplicate $id.
+          status=0
+          for schema in "${schemas[@]}"; do
             echo "Compiling schema: $schema"
-            ajv compile -s "$schema" --spec=draft2020 -c ajv-formats
+            refs=()
+            for other in "${schemas[@]}"; do
+              [ "$other" = "$schema" ] || refs+=(-r "$other")
+            done
+            ajv compile -s "$schema" "${refs[@]}" --spec=draft2020 -c ajv-formats || status=1
           done
+          # Report every bad schema in one run rather than stopping at the first.
+          exit $status
 
       - name: Validate JSON files syntax
         run: |

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -45,11 +45,31 @@ jobs:
       - name: Validate JSON Schema files
         run: |
           echo "Validating JSON Schema files structure..."
-          # Find all JSON files in any 'schemas' folder and any files ending with 'schema.json'
+          # Discover schemas by what the documents are, not what they are
+          # named. The previous globs ("*/schemas/*.json" or "*schema.json")
+          # silently excluded every composed schema and bundle — exactly the
+          # files that carry cross-schema "$ref"s, so the refs most likely to
+          # break were the ones never compiled.
+          #
+          # A schema declares "$schema" and "$id" AND asserts something about
+          # instances. That last clause is what separates a schema from a data
+          # document that merely labels itself with the same two keys:
+          # extensions/registry.json has both, but no type/properties/allOf/
+          # $defs, and compiling it as a schema would fail on strict-mode
+          # unknown keywords. Examples have no "$id" and are covered by the
+          # next step instead.
           mapfile -t schemas < <(
-            find . -type f \( -path "*/schemas/*.json" -o -name "*schema.json" \) \
-              -not -path "./node_modules/*" | sort
+            find . -type f -name "*.json" -not -path "./node_modules/*" | sed 's|^\./||' | sort | while read -r f; do
+              jq -e '
+                type == "object" and has("$schema") and has("$id")
+                and (has("type") or has("properties") or has("allOf")
+                     or has("anyOf") or has("oneOf") or has("$defs"))
+              ' "$f" >/dev/null 2>&1 && echo "$f" || true
+            done
           )
+          printf '%s\n' "${schemas[@]}" > "$RUNNER_TEMP/schemas.txt"
+          echo "Discovered ${#schemas[@]} schema(s):"
+          printf '  %s\n' "${schemas[@]}"
           # Every other schema is registered with -r so that a cross-schema
           # "$ref" by $id resolves (e.g. the playlists extension referencing
           # core ref-manifest.json). The schema under compile is excluded from
@@ -64,6 +84,32 @@ jobs:
             ajv compile -s "$schema" "${refs[@]}" --spec=draft2020 -c ajv-formats || status=1
           done
           # Report every bad schema in one run rather than stopping at the first.
+          exit $status
+
+      - name: Validate examples against their composed schema
+        run: |
+          # Compiling a composed schema proves it is well-formed; it does not
+          # prove the examples we ship still satisfy it. Without this, an
+          # example can drift from the extension it demonstrates and nothing
+          # notices.
+          mapfile -t schemas < "$RUNNER_TEMP/schemas.txt"
+          status=0
+          shopt -s nullglob
+          for dir in extensions/*/examples; do
+            ext="$(dirname "$dir")"
+            composed="$ext/playlist_with_extension.json"
+            [ -f "$composed" ] || { echo "No composed schema for $ext, skipping"; continue; }
+            examples=("$dir"/*.json)
+            [ ${#examples[@]} -gt 0 ] || { echo "No examples in $dir, skipping"; continue; }
+            refs=()
+            for other in "${schemas[@]}"; do
+              [ "$other" = "$composed" ] || refs+=(-r "$other")
+            done
+            echo "Validating ${#examples[@]} example(s) in $dir against $composed"
+            ajv validate -s "$composed" "${refs[@]}" \
+              $(printf -- '-d %s ' "${examples[@]}") \
+              --spec=draft2020 -c ajv-formats || status=1
+          done
           exit $status
 
       - name: Validate JSON files syntax


### PR DESCRIPTION
## Problem

The `Validate JSON Schema files` step compiles each schema in isolation:

```bash
ajv compile -s "$schema" --spec=draft2020 -c ajv-formats
```

With no `-r`, ajv has no other schema registered, so a `$ref` from one schema to another **by `$id`** cannot resolve. The harness has never supported cross-schema references.

This is what blocks #38. Its new `$ref` from the playlists extension to core `ref-manifest.json` fails with:

```
schema ./extensions/playlists/schema.json is invalid
error: can't resolve reference https://dp1.feralfile.com/schemas/v1.1.0/ref-manifest.json
       from id https://dp1.feralfile.com/extensions/playlists/v0.1.0/schema.json
```

The schema in #38 is correct — the referenced file exists at `core/v1.1.0/schemas/ref-manifest.json` with exactly that `$id`. Only the CI step is wrong.

## Change

- Register every *other* discovered schema with `-r` before compiling, so cross-schema `$ref` by `$id` resolves. The schema under compile is excluded from its own `-r` set, since re-adding it would be a duplicate `$id`.
- Collect failures and `exit` at the end rather than dying on the first, so one bad schema no longer hides the ones after it.

Schema discovery is unchanged — same `find`, same file set.

## Verification

Run locally with `ajv-cli@5` + `ajv-formats`, executing the workflow step as extracted from the YAML under `bash -e`:

| Case | Result |
|---|---|
| This branch, all 5 schemas | all valid, exit 0 |
| The #38 branch (currently red) | playlists extension **valid**, exit 0 |
| Deliberate unresolvable `$ref` added | exit 1, names the offending schema, still checks the rest |

## Note

#38 needs this merged and then a CI re-run to go green.