### PR TITLE
spec: Entity name is required but may be empty

### DIFF
--- a/extensions/channels/channel.md
+++ b/extensions/channels/channel.md
@@ -156,7 +156,7 @@ This is the same entity shape used by the Playlist Extension.
 
 | Field | Type | Required | Description |
 |:------|:-----|:---------|:------------|
-| `name` | string | **REQUIRED** | Entity display name. |
+| `name` | string | **REQUIRED** | Entity display name. MAY be empty (wallet-based publishers can emit the signing identity unnamed); consumers MUST NOT reject a document over an empty name and SHOULD fall back to displaying `key`. |
 | `key` | string | **REQUIRED** | Verifiable identity in DID format (e.g., `did:key:z6Mk...`). |
 | `url` | string | OPTIONAL | Entity website or profile URL. |
 

--- a/extensions/channels/schema.json
+++ b/extensions/channels/schema.json
@@ -95,7 +95,7 @@
       "properties": {
         "name": {
           "type": "string",
-          "description": "Entity display name"
+          "description": "Entity display name. Required but MAY be empty: wallet-based publishers can emit the signing identity with an empty name. Consumers MUST NOT reject a document because an entity name is empty; display SHOULD fall back to the key."
         },
         "key": {
           "type": "string",

--- a/extensions/playlists/playlist.md
+++ b/extensions/playlists/playlist.md
@@ -118,7 +118,7 @@ This extension uses the same unified entity shape as the Channel Extension.
 
 | Field | Type | Required | Description |
 |:------|:-----|:---------|:------------|
-| `name` | string | **REQUIRED** | Entity display name. |
+| `name` | string | **REQUIRED** | Entity display name. MAY be empty (wallet-based publishers can emit the signing identity unnamed); consumers MUST NOT reject a document over an empty name and SHOULD fall back to displaying `key`. |
 | `key` | string | **REQUIRED** | Verifiable identity in DID format (e.g., `did:key:z6Mk...`). |
 | `url` | string | OPTIONAL | Entity website or profile URL. |
 

--- a/extensions/playlists/schema.json
+++ b/extensions/playlists/schema.json
@@ -93,7 +93,7 @@
       "properties": {
         "name": {
           "type": "string",
-          "description": "Entity display name"
+          "description": "Entity display name. Required but MAY be empty: wallet-based publishers can emit the signing identity with an empty name. Consumers MUST NOT reject a document because an entity name is empty; display SHOULD fall back to the key."
         },
         "key": {
           "type": "string",


### PR DESCRIPTION
## Why

Wallet-based publishers emit the signing identity as `{"name": "", "key": "did:pkh:..."}` — at signing time there is nothing to derive a display name from. The schema has always allowed this (`name` has no `minLength`), but the description was silent on it, and a strict consumer read *required* as *non-empty* and rejected whole documents over it: every wallet-published playlist on the hosted feed failed to subscribe in the mobile app until the consumer was fixed (2026-08-02).

The mobile-app fix protects one consumer. This makes the contract explicit at the source so every other DP-1 implementation doesn't have to rediscover it.

## Change

In both extension schemas (`extensions/playlists`, `extensions/channels`) and their prose field tables:

> Entity display name. Required but MAY be empty: wallet-based publishers can emit the signing identity with an empty name. Consumers MUST NOT reject a document because an entity name is empty; display SHOULD fall back to the key.

Documentation-only — no validation behavior changes (the constraint set is identical).