### PR TITLE
fix(core): drop w/h from Thumbnail required fields

### DIFF
--- a/core/v1.1.0/ref-manifest.md
+++ b/core/v1.1.0/ref-manifest.md
@@ -70,6 +70,8 @@ Carries human-readable information used for labeling, crediting, and exhibition.
 
 All text fields are UTF-8 encoded and localizable through the `i18n` block.
 
+Within `thumbnails`, each entry requires only `uri`. `w` and `h` are **optional**: when present they are the intrinsic image dimensions in pixels; producers that only hold a bare thumbnail URL omit them rather than guess. Consumers **MUST** treat `w` and `h` as possibly absent.
+
 ---
 
 ## 5. Controls Block

--- a/core/v1.1.0/schemas/ref-manifest.json
+++ b/core/v1.1.0/schemas/ref-manifest.json
@@ -119,7 +119,7 @@
     "Thumbnail": {
       "type": "object",
       "description": "Thumbnail image specification",
-      "required": ["uri", "w", "h"],
+      "required": ["uri"],
       "properties": {
         "uri": {
           "type": "string",
@@ -128,12 +128,12 @@
         },
         "w": {
           "type": "integer",
-          "description": "Width in pixels",
+          "description": "Intrinsic image width in pixels. Optional: producers that only hold a bare thumbnail URL omit it rather than guess.",
           "minimum": 1
         },
         "h": {
           "type": "integer",
-          "description": "Height in pixels",
+          "description": "Intrinsic image height in pixels. Optional: producers that only hold a bare thumbnail URL omit it rather than guess.",
           "minimum": 1
         },
         "sha256": {

--- a/core/v1.1.0/spec.md
+++ b/core/v1.1.0/spec.md
@@ -423,6 +423,8 @@ Returns array of playlist summaries.
 
 ## 16 · Changelog
 
+* **Editorial (2026-08-12)** Ref-manifest schema (`schemas/ref-manifest.json`): `Thumbnail.w` and `Thumbnail.h` are now **optional** (`required` relaxed from `["uri", "w", "h"]` to `["uri"]`) — producers holding only a bare thumbnail URL omit dimensions rather than guess; when present they are the intrinsic image dimensions in pixels. Loosening only: every previously valid document remains valid, but consumers **MUST** treat `w`/`h` as possibly absent.
+
 * **Editorial (2026-07-31)** Removed the beta Playlist-Group (Exhibition) object: §15.2, the `playlist-group.json` schema, and the terminology entry. Channels (extensions/channels) superseded it before it saw production use — zero groups were ever published; the channels extension no longer references it. Historical changelog entries below are unchanged.
 
 * **v1.1.0 (2025-10-17)** Introduced **multi-signature chain** model with new `signatures` array field. Supports multiple signing entities with distinct roles (`curator`, `feed`, `agent`, `institution`, `licensor`). Signatures use DID-based key identifiers (`kid`) and support multiple algorithms (`ed25519`, `eip191`, `ecdsa-p256`,etc.). Legacy single `signature` field deprecated but remains supported for backward compatibility. Players can verify keys via DID resolution, JWKS endpoints, or local trust stores. See §7.1 for complete specification.


### PR DESCRIPTION
## Summary

Fixes feral-file/ff-app#666 — `Thumbnail` in the core Ref Manifest schema required `uri`, `w` **and** `h`. Producers routinely hold only a bare thumbnail URL with no dimensions attached, which left two bad options: fabricate `w`/`h`, or drop the thumbnail entirely. Requiring dimensions and letting producers guess is worse than not carrying them.

Nothing in the repo justified the requirement. A full search finds `w` and `h` documented only in their own schema `description` lines — which pixels they mean is never stated, whether they must match the file at `uri` is never constrained, and no rationale is given anywhere. The requirement cost producers real data while guaranteeing nothing to consumers.

## Changes

`core/v1.1.0/schemas/ref-manifest.json`
- `Thumbnail.required` relaxed from `["uri", "w", "h"]` to `["uri"]`.
- `w`/`h` descriptions now state they are the **intrinsic image dimensions in pixels** and optional.

`core/v1.1.0/spec.md` — Editorial (2026-08-12) changelog entry.
`core/v1.1.0/ref-manifest.md` — §4 note stating the optionality and the consumer caveat.

## Backward compatibility

**Loosening only** — every previously valid manifest remains valid. The one real risk is on the consumer side: code with non-null typed `w`/`h` will now see them absent. That caveat is stated explicitly in both the core changelog and `ref-manifest.md` rather than left implicit.

## Scope note

An earlier revision of this PR also added item-level `artists` and `thumbnails` to the playlists extension, following the original proposal in the issue. That was dropped: `inlineManifest` (#38) already carries the entire standardized metadata block — including `metadata.artists` and `metadata.thumbnails` — directly on a `PlaylistItem` with no hosting, no versioning, and no extra fetch. Adding item-level parallels would have meant two carriage paths for the same data in the same document, plus precedence rules to disambiguate them. This relaxation is the only change actually required.

## Verification

- `markdownlint '**/*.md'` — pass
- `jq empty` on all JSON — pass
- `ajv compile` (draft 2020-12, cross-refs registered as in CI) on all 7 discovered schemas — pass
- `ajv validate` of the shipped example against the composed schema — pass
- End-to-end on the real use case: an item whose `inlineManifest` carries `metadata.artists` plus a thumbnail with only `uri` → **valid**; a thumbnail missing `uri` → **still rejected**

🤖 Generated with [Claude Code](https://claude.com/claude-code)