### PR TITLE
fix(playlists): single-item composed schema now enforces inlineManifest

### DIFF
--- a/extensions/playlists/playlist.md
+++ b/extensions/playlists/playlist.md
@@ -6,7 +6,7 @@
 **Status:** Draft Extension  
 **DP-1 compatibility:** v1.0.0+  
 **Published:** 2026-03-11  
-**Updated:** 2026-07-21
+**Updated:** 2026-08-13
 
 ---
 
@@ -627,9 +627,10 @@ Response items **MUST** conform to the DP-1 PlaylistItem schema specified by the
 - `provenance` (object)
 - `note` (object; experimental intermission per §3.4)
 - `displayAt` (string; ISO 8601 scheduling datetime per §3.5) — optional on mapped items
+- `inlineManifest` (object; a full Ref Manifest carried inline per §3.6, validated by the unmodified Ref Manifest schema)
 - All other PlaylistItem fields per DP-1 §3.2
 
-**Validation path:** Core `itemSchema` versions define base PlaylistItem fields. When the playlists extension is in use, items **MUST** be validated against core PlaylistItem composed with the extension item overlay (`note`, `displayAt`) — the same overlay used for static items in `playlist_with_extension.json` / `playlist_item_with_extension.json`. This applies to items in the signed playlist document and to items accepted from `dynamicQuery` before they enter the playlist item list. How `displayAt` affects playback after acceptance is defined only in §3.5 (independent of item sourcing).
+**Validation path:** Core `itemSchema` versions define base PlaylistItem fields. When the playlists extension is in use, items **MUST** be validated against core PlaylistItem composed with the extension item overlay (`note`, `displayAt`, `inlineManifest`) — the same overlay used for static items in `playlist_with_extension.json` / `playlist_item_with_extension.json`. Both composed schemas reference a single definition of that overlay (`schema.json#/$defs/PlaylistItemExtension`), so the whole-playlist and single-item paths enforce identical per-item constraints. This applies to items in the signed playlist document and to items accepted from `dynamicQuery` before they enter the playlist item list. How `displayAt` affects playback after acceptance is defined only in §3.5 (independent of item sourcing).
 
 **Field mapping (optional):**
 
@@ -905,6 +906,14 @@ Current version: **0.2.0**
 ---
 
 ## 11 · Changelog
+
+### Amendment (2026-08-13) — single-item schema covers inlineManifest
+
+- Fixed: `playlist_item_with_extension.json` hand-copied the per-item overlay and listed only `note` and `displayAt`, so validating a **single item** silently ignored `inlineManifest` while validating a **whole playlist** checked it. That contradicted §3.6, which requires validators to apply the unmodified Ref Manifest schema to `inlineManifest`, on exactly the path §4.5.1 mandates for `dynamicQuery` items.
+- The overlay is now defined once as `schema.json#/$defs/PlaylistItemExtension` and referenced from both composed schemas (`playlist_with_extension.json` through the fragment's `items`, `playlist_item_with_extension.json` directly), so the two validation paths cannot drift apart again. `$ref` targets a `$defs` entry rather than `#/properties/items/items`, which would silently retarget if `items` ever changed shape.
+- §4.5.1 corrected: the optional-fields list and the **Validation path** paragraph now both name `inlineManifest` alongside `note` and `displayAt`.
+- Loosening-plus-editorial: no document that validates today stops validating. A single item carrying a malformed `inlineManifest` — which passed before — is now correctly rejected.
+- No `$id` changed; the extension remains **v0.2.0** (draft).
 
 ### v0.2.0 (2026-07-21) — displayAt scheduling
 

--- a/extensions/playlists/playlist_item_with_extension.json
+++ b/extensions/playlists/playlist_item_with_extension.json
@@ -2,21 +2,13 @@
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://dp1.feralfile.com/extensions/playlists/v0.2.0/playlist_item_with_extension.json",
   "title": "DP-1 PlaylistItem with playlists extension (composed)",
-  "description": "Validates a single playlist item against core PlaylistItem plus optional playlists-extension fields (note, displayAt). Used when accepting dynamicQuery items under the playlists extension.",
+  "description": "Validates a single playlist item against core PlaylistItem plus optional playlists-extension fields (note, displayAt, inlineManifest). The overlay is referenced from the extension fragment rather than copied, so this schema and playlist_with_extension.json always enforce the same per-item fields. Used when accepting dynamicQuery items under the playlists extension.",
   "allOf": [
     {
       "$ref": "https://dp1.feralfile.com/schemas/v1.1.0/playlist.json#/$defs/PlaylistItem"
     },
     {
-      "type": "object",
-      "properties": {
-        "note": {
-          "$ref": "https://dp1.feralfile.com/extensions/playlists/v0.2.0/schema.json#/$defs/Note"
-        },
-        "displayAt": {
-          "$ref": "https://dp1.feralfile.com/extensions/playlists/v0.2.0/schema.json#/$defs/DisplayAt"
-        }
-      }
+      "$ref": "https://dp1.feralfile.com/extensions/playlists/v0.2.0/schema.json#/$defs/PlaylistItemExtension"
     }
   ]
 }

--- a/extensions/playlists/schema.json
+++ b/extensions/playlists/schema.json
@@ -12,19 +12,7 @@
       "type": "array",
       "description": "Per-item extension fields. Composed with the core playlist schema via allOf: each element must still satisfy PlaylistItem from the bundle, and may include optional note, displayAt, and inlineManifest.",
       "items": {
-        "type": "object",
-        "properties": {
-          "note": {
-            "$ref": "#/$defs/Note"
-          },
-          "displayAt": {
-            "$ref": "#/$defs/DisplayAt"
-          },
-          "inlineManifest": {
-            "$ref": "https://dp1.feralfile.com/schemas/v1.1.0/ref-manifest.json",
-            "description": "A full DP-1 Ref Manifest document carried inline — same schema and validation as a manifest fetched via ref. When both are present, ref overrides inlineManifest."
-          }
-        }
+        "$ref": "#/$defs/PlaylistItemExtension"
       }
     },
     "curators": {
@@ -51,6 +39,22 @@
     }
   },
   "$defs": {
+    "PlaylistItemExtension": {
+      "type": "object",
+      "description": "The playlists-extension overlay applied to a single PlaylistItem. Defined once here and referenced by both composed schemas (playlist_with_extension.json via this fragment's items, and playlist_item_with_extension.json directly) so the two validation paths cannot drift.",
+      "properties": {
+        "note": {
+          "$ref": "#/$defs/Note"
+        },
+        "displayAt": {
+          "$ref": "#/$defs/DisplayAt"
+        },
+        "inlineManifest": {
+          "$ref": "https://dp1.feralfile.com/schemas/v1.1.0/ref-manifest.json",
+          "description": "A full DP-1 Ref Manifest document carried inline — same schema and validation as a manifest fetched via ref. When both are present, ref overrides inlineManifest."
+        }
+      }
+    },
     "DisplayAt": {
       "description": "ISO 8601 subset when this item becomes eligible for playback. Local datetime without timezone: display-locale local. RFC 3339 date-time with Z or offset (hours 00-23, minutes 00-59): absolute/global. Date-only (YYYY-MM-DD) is not accepted. Top-level item field (same level as source), not inside display. Patterns are syntactic only; invalid calendar values are rejected at resolve time.",
       "oneOf": [

--- a/extensions/registry.json
+++ b/extensions/registry.json
@@ -1,8 +1,8 @@
 {
   "title": "DP-1 Extension Registry",
   "description": "Official registry of DP-1 protocol extensions",
-  "version": "1.0.5",
-  "lastUpdated": "2026-08-03T00:00:00Z",
+  "version": "1.0.6",
+  "lastUpdated": "2026-08-13T00:00:00Z",
   "extensions": [
     {
       "id": "channels",
@@ -69,6 +69,15 @@
     }
   ],
   "changelog": [
+    {
+      "version": "1.0.6",
+      "date": "2026-08-13T00:00:00Z",
+      "changes": [
+        "Playlist extension: playlist_item_with_extension.json now enforces inlineManifest. The single-item composed schema hand-copied the per-item overlay and listed only note and displayAt, so a dynamicQuery item with a malformed inline Ref Manifest passed validation despite the §3.6 MUST; the whole-playlist path was unaffected.",
+        "Playlist extension: the per-item overlay is defined once as schema.json#/$defs/PlaylistItemExtension and referenced by both composed schemas, so the whole-playlist and single-item validation paths can no longer drift apart.",
+        "Playlist extension: §4.5.1 field list and Validation path prose corrected to name inlineManifest; extension version remains draft v0.2.0 and no schema $id changed."
+      ]
+    },
     {
       "version": "1.0.5",
       "date": "2026-08-03T00:00:00Z",


### PR DESCRIPTION
Closes #45.

## What drifted, and why

`extensions/playlists/schema.json` carries `inlineManifest` in its per-item overlay. `extensions/playlists/playlist_item_with_extension.json` hand-copies that overlay and listed only `note` and `displayAt`. So validating a **whole playlist** checked the nested manifest, while validating a **single item** silently ignored it — JSON Schema treats an undeclared property as an unconstrained one.

That contradicts §3.6, which says validators **MUST** apply the unmodified Ref Manifest schema to `inlineManifest`. And the affected path is the one §4.5.1 mandates for `dynamicQuery` items — the least trusted input in the protocol. An indexer returning a manifest with a missing `locale`, a non-semver `refVersion`, or a thumbnail with `w: 0` passed validation on `main`.

The drift was mechanical, not a design decision: `playlist_item_with_extension.json` was added later (`cafd9d9a`) and copied the overlay instead of referencing it; ten days later #38 added a third field to the fragment only, and the copy had no way to follow. `playlist_with_extension.json` composes by `$ref` and so picked the field up for free, which is why only the single-item path is affected. Signed static playlists are unaffected.

## Why `$defs`, not a second copy

Copying `inlineManifest` across closes today's gap and leaves the same drift mechanism armed for the next field. Instead the overlay is now defined once as `schema.json#/$defs/PlaylistItemExtension` and referenced from both sites — `playlist_with_extension.json` through the fragment's `items`, `playlist_item_with_extension.json` directly. One definition, so the two paths cannot diverge again.

The `$ref` points at a `$defs` entry rather than `#/properties/items/items`. The latter resolves correctly today, but it points into a validation-keyword location, so it would silently retarget if `items` ever became `prefixItems` or gained a wrapper.

Verified that the overlay's internal `#/$defs/Note` and `#/$defs/DisplayAt` references still resolve when the overlay is reached from the other file — `$ref` resolves against the base URI of the containing schema, not the referrer. The named-`$defs` reference behaves identically to the inline copy; no resolution caveat.

## Changes

- `extensions/playlists/schema.json` — new `$defs.PlaylistItemExtension` holding `note` / `displayAt` / `inlineManifest` with their existing descriptions; `properties.items.items` becomes `{ "$ref": "#/$defs/PlaylistItemExtension" }`.
- `extensions/playlists/playlist_item_with_extension.json` — `allOf[1]` is now a `$ref` to that definition; `description` names all three fields.
- `extensions/playlists/playlist.md` — §4.5.1 optional-field list and **Validation path** paragraph both name `inlineManifest`; §11 amendment entry; **Updated:** date.
- `extensions/registry.json` — patch bump `1.0.5` → `1.0.6` with a changelog entry, matching the granularity of 1.0.3 (a `schema.json` enum correction) and 1.0.1. The playlists extension's own `version` stays `0.2.0`.

## Verification

`markdownlint` clean, `jq empty` clean on every JSON file. The `lint-json-schema` job's own discovery + compile loop run locally (all 7 discovered schemas compiled with the other 6 registered via `-r`, so cross-schema `$ref`s by `$id` actually resolve): all valid, and the example still validates against `playlist_with_extension.json`.

Compilation only proves well-formedness, so behaviour was checked directly with Ajv 2020 on `main` vs. this branch, same fixtures:

| Case | Schema | `main` | this branch |
|:--|:--|:--|:--|
| item + **bad** `inlineManifest` | `playlist_item_with_extension.json` | ✅ accepted (the bug) | ❌ **rejected** |
| item + good `inlineManifest` | `playlist_item_with_extension.json` | ✅ accepted | ✅ accepted |
| playlist + **bad** `inlineManifest` | `playlist_with_extension.json` | ❌ rejected | ❌ rejected |
| playlist + good `inlineManifest` | `playlist_with_extension.json` | ✅ accepted | ✅ accepted |
| item + `note: { text: "" }` | `playlist_item_with_extension.json` | ❌ rejected | ❌ rejected |
| item + valid `note` | `playlist_item_with_extension.json` | ✅ accepted | ✅ accepted |
| item + `displayAt: "2026-07-21"` | `playlist_item_with_extension.json` | ❌ rejected | ❌ rejected |
| item + valid `displayAt` | `playlist_item_with_extension.json` | ✅ accepted | ✅ accepted |

Exactly one row changes — the bug. The bad manifest (`refVersion: "nope"`, no `locale`, thumbnail `w: 0`) now reports at `/inlineManifest`, `/inlineManifest/refVersion`, `/inlineManifest/metadata/thumbnails/default/w` through the single-item schema, mirroring the `/items/0/inlineManifest…` paths the playlist path already produced. `note` and `displayAt` validation is unchanged through the new reference.

Loosening-plus-editorial: no document that validates today stops validating. A document that validates *incorrectly* today starts being rejected, which is the point.

## No `$id` moved

Every `$id` keeps its `v0.2.0` segment. #38 added `inlineManifest` within v0.2.0 and this is the same kind of additive/loosening correction, so the extension stays draft v0.2.0.

## Downstream

`dp1-js` (display-protocol/dp1-js#19) keeps its embedded schemas byte-identical to this repo and works around this gap in code — `PlaylistItemBuilder.build()` runs the core ref-manifest validator on a nested manifest itself. That workaround can be deleted once this lands.

## Left out of scope, deliberately

- **CI never exercises the single-item schema.** The "Validate examples against their composed schema" step only validates examples against `playlist_with_extension.json`; `playlist_item_with_extension.json` is compiled but never run against an instance, which is precisely why a missing field was invisible. Filed separately rather than widening this PR — it needs a new item-level example fixture and a workflow change.
- **Appendix A's schema fragment is stale.** It mirrors `schema.json` but predates #38, so it still shows an item overlay with only `note` and `displayAt` and no `inlineManifest`. It is explicitly illustrative ("prefer the file on disk when validating"), and §11 has no amendment entry for #38 either. Both are #38 fallout rather than #45, so noted here rather than fixed in passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
